### PR TITLE
Add basic web UI for IA Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ Run `python -m ia_manager` to start the interactive shell. Type `help` inside
 the shell to see available commands. The main commands include creating and
 listing projects, managing tasks, showing the status, planning a day and
 generating documentation.
+
+## Web interface
+
+A simple Flask-based web UI is available for managing projects and tasks.
+Run it with:
+
+```
+python -m ia_manager.web.server
+```
+
+The interface lists projects and their tasks and includes a chat area placeholder.

--- a/ia_manager/web/server.py
+++ b/ia_manager/web/server.py
@@ -1,0 +1,112 @@
+from flask import Flask, jsonify, request, render_template
+from ..services import storage, planner, logger
+from ..models.project import Project
+from ..models.task import Task
+
+app = Flask(__name__, template_folder='templates', static_folder='static')
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/projects', methods=['GET'])
+def get_projects():
+    projects = storage.load_projects()
+    return jsonify([p.to_dict() for p in projects])
+
+@app.route('/api/projects', methods=['POST'])
+def create_project():
+    data = request.json
+    projects = storage.load_projects()
+    project_id = max([p.id for p in projects], default=0) + 1
+    project = Project(
+        id=project_id,
+        name=data.get('name', f'Project {project_id}'),
+        description=data.get('description', ''),
+        priority=data.get('priority', 3),
+        deadline=data.get('deadline'),
+    )
+    projects.append(project)
+    storage.save_projects(projects)
+    logger.log(f"Web: added project {project.name}")
+    return jsonify(project.to_dict())
+
+@app.route('/api/projects/<int:pid>', methods=['GET'])
+def get_project(pid):
+    projects = storage.load_projects()
+    proj = next((p for p in projects if p.id == pid), None)
+    if not proj:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(proj.to_dict())
+
+@app.route('/api/projects/<int:pid>/tasks', methods=['POST'])
+def add_task(pid):
+    data = request.json
+    projects = storage.load_projects()
+    proj = next((p for p in projects if p.id == pid), None)
+    if not proj:
+        return jsonify({'error': 'not found'}), 404
+    task_id = max([t.id for t in proj.tasks], default=0) + 1
+    task = Task(
+        id=task_id,
+        name=data.get('name', f'Task {task_id}'),
+        estimated=data.get('estimated'),
+        deadline=data.get('deadline'),
+        importance=data.get('importance', 3),
+        description=data.get('description', '')
+    )
+    proj.tasks.append(task)
+    storage.save_projects(projects)
+    logger.log(f"Web: added task {task.name} to project {proj.name}")
+    return jsonify(task.to_dict())
+
+@app.route('/api/tasks/<int:tid>', methods=['PUT'])
+def update_task(tid):
+    data = request.json
+    projects = storage.load_projects()
+    for p in projects:
+        for t in p.tasks:
+            if t.id == tid:
+                t.name = data.get('name', t.name)
+                t.status = data.get('status', t.status)
+                t.estimated = data.get('estimated', t.estimated)
+                t.deadline = data.get('deadline', t.deadline)
+                t.importance = data.get('importance', t.importance)
+                t.description = data.get('description', t.description)
+                storage.save_projects(projects)
+                logger.log(f"Web: updated task {tid}")
+                return jsonify(t.to_dict())
+    return jsonify({'error': 'not found'}), 404
+
+@app.route('/api/tasks/<int:tid>/done', methods=['POST'])
+def mark_task_done(tid):
+    projects = storage.load_projects()
+    for p in projects:
+        for t in p.tasks:
+            if t.id == tid:
+                t.status = 'done'
+                storage.save_projects(projects)
+                logger.log(f"Web: done task {tid}")
+                return jsonify({'status': 'ok'})
+    return jsonify({'error': 'not found'}), 404
+
+@app.route('/api/tasks/<int:tid>', methods=['DELETE'])
+def delete_task(tid):
+    projects = storage.load_projects()
+    for p in projects:
+        for t in list(p.tasks):
+            if t.id == tid:
+                p.tasks.remove(t)
+                storage.save_projects(projects)
+                logger.log(f"Web: deleted task {tid}")
+                return jsonify({'status': 'ok'})
+    return jsonify({'error': 'not found'}), 404
+
+@app.route('/api/recommendations')
+def recommendations():
+    projs = storage.load_projects()
+    recs = planner.suggest_tasks(projs)
+    return jsonify(recs)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/ia_manager/web/static/main.js
+++ b/ia_manager/web/static/main.js
@@ -1,0 +1,62 @@
+let currentProject = null;
+
+async function loadProjects() {
+    const res = await fetch('/api/projects');
+    const projects = await res.json();
+    const list = document.getElementById('project-list');
+    list.innerHTML = '';
+    projects.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = p.name;
+        li.onclick = () => selectProject(p.id, p.name);
+        list.appendChild(li);
+    });
+}
+
+async function selectProject(id, name) {
+    currentProject = id;
+    document.getElementById('tasks-title').textContent = `Tasks - ${name}`;
+    const res = await fetch(`/api/projects/${id}`);
+    const proj = await res.json();
+    const list = document.getElementById('task-list');
+    list.innerHTML = '';
+    proj.tasks.forEach(t => {
+        const li = document.createElement('li');
+        li.textContent = t.name;
+        if (t.status === 'done') li.classList.add('done');
+        li.onclick = () => markDone(t.id);
+        list.appendChild(li);
+    });
+}
+
+async function createProject() {
+    const name = document.getElementById('new-project-name').value.trim();
+    if (!name) return;
+    await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+    });
+    document.getElementById('new-project-name').value = '';
+    loadProjects();
+}
+
+async function createTask() {
+    if (!currentProject) return;
+    const name = document.getElementById('new-task-name').value.trim();
+    if (!name) return;
+    await fetch(`/api/projects/${currentProject}/tasks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+    });
+    document.getElementById('new-task-name').value = '';
+    selectProject(currentProject, document.getElementById('tasks-title').textContent);
+}
+
+async function markDone(id) {
+    await fetch(`/api/tasks/${id}/done`, { method: 'POST' });
+    if (currentProject) selectProject(currentProject, document.getElementById('tasks-title').textContent);
+}
+
+document.addEventListener('DOMContentLoaded', loadProjects);

--- a/ia_manager/web/static/styles.css
+++ b/ia_manager/web/static/styles.css
@@ -1,0 +1,47 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    height: 100vh;
+}
+#container {
+    display: flex;
+    width: 100%;
+}
+aside {
+    width: 20%;
+    padding: 10px;
+    border-right: 1px solid #ddd;
+    box-sizing: border-box;
+    overflow-y: auto;
+}
+main#chat {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+#chat-log {
+    flex: 1;
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+    overflow-y: auto;
+}
+#chat-input {
+    display: flex;
+    padding: 10px;
+}
+#chat-input input {
+    flex: 1;
+    margin-right: 5px;
+}
+.form {
+    margin-top: 10px;
+}
+ul {
+    list-style: none;
+    padding: 0;
+}
+li.done {
+    text-decoration: line-through;
+}

--- a/ia_manager/web/templates/index.html
+++ b/ia_manager/web/templates/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>IA Manager</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<div id="container">
+    <aside id="projects">
+        <h2>Projects</h2>
+        <ul id="project-list"></ul>
+        <div class="form">
+            <input id="new-project-name" placeholder="New project name">
+            <button onclick="createProject()">Add</button>
+        </div>
+    </aside>
+    <main id="chat">
+        <div id="chat-log"></div>
+        <div id="chat-input">
+            <input id="message" placeholder="Chat with agent" disabled>
+            <button disabled>Send</button>
+        </div>
+    </main>
+    <aside id="tasks">
+        <h2 id="tasks-title">Tasks</h2>
+        <ul id="task-list"></ul>
+        <div class="form">
+            <input id="new-task-name" placeholder="New task" />
+            <button onclick="createTask()">Add</button>
+        </div>
+    </aside>
+</div>
+<script src="/static/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based web server under `ia_manager.web`
- create basic single page interface with project and task management
- include CSS/JS assets
- document how to launch the web app in README
- add gitignore for pycache

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845dbb766348324a352255ba133892e