### PR TITLE
Add persistent memory and note system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ the shell to see available commands. The main commands include creating and
 listing projects, managing tasks, showing the status, planning a day and
 generating documentation.
 
+## Persistent memory and notes
+
+KroniX now stores user preferences in `memory.json` and personal notes in
+`notes.json` under the `ia_manager/data` directory. Use the new commands to
+interact with this memory:
+
+```
+remember TEXT [--project NAME --tags tag1 tag2]   # store a note
+recall KEYWORD                                   # search notes
+set_sarcasm LEVEL                                # sarcasm level 0-3
+set_name NAME                                    # set your name
+```
+
+The interactive shell greets you using the stored name and responds with a
+slightly sarcastic tone depending on the chosen level.
+
 ## Task scheduling
 
 Tasks now support planned start and end times as well as an optional duration.

--- a/ia_manager/cli/shell.py
+++ b/ia_manager/cli/shell.py
@@ -1,6 +1,8 @@
 import shlex
 from ..utils import color, Fore
 from .commands import build_parser
+from ..services import memory
+from .. import personality
 
 LOGO = r"""
   ___        __  __
@@ -26,6 +28,10 @@ COMMAND_HELP = """Available commands:
   show_status
   plan_day [JJ/MM]
   recommend_task
+  remember TEXT [--project NAME --tags tag1 tag2]
+  recall KEYWORD
+  set_sarcasm LEVEL
+  set_name NAME
   calendar
   assistant
   help
@@ -36,11 +42,14 @@ def interactive_loop():
     parser = build_parser()
     print(color(LOGO, Fore.CYAN))
     print(color(COMMAND_HELP, Fore.YELLOW))
+    user = memory.load_user()
+    personality.say(f"Hello {user.get('name','user')}!")
     while True:
         try:
             raw = input(color("ia> ", Fore.GREEN)).strip()
         except (EOFError, KeyboardInterrupt):
             print()
+            personality.say("See you!")
             break
         if not raw:
             continue
@@ -58,5 +67,5 @@ def interactive_loop():
         except SystemExit:
             # argparse errors
             pass
-    print(color("Bye!", Fore.CYAN))
+    personality.say("Bye!")
 

--- a/ia_manager/data/memory.json
+++ b/ia_manager/data/memory.json
@@ -1,0 +1,1 @@
+{\n  "name": "User",\n  "sarcasm": 1\n}

--- a/ia_manager/data/notes.json
+++ b/ia_manager/data/notes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 1,
+    "text": "First note",
+    "tags": [
+      "test"
+    ],
+    "project": null
+  }
+]

--- a/ia_manager/personality.py
+++ b/ia_manager/personality.py
@@ -1,0 +1,26 @@
+import random
+from .services import memory
+from .utils import color, Fore
+
+
+def _prefix() -> str:
+    user = memory.load_user()
+    level = user.get("sarcasm", 1)
+    if level <= 0:
+        return ""
+    mild = ["Alright,", "Okay,", "Sure,", "Fine,"]
+    strong = [
+        "I guess I'll handle that.",
+        "Because that's exactly what I wanted to do.",
+        "As if I had a choice.",
+    ]
+    choices = mild + strong if level >= 2 else mild
+    return random.choice(choices) + " "
+
+
+def say(message: str):
+    print(color(_prefix() + message, Fore.MAGENTA))
+
+
+def format(message: str) -> str:
+    return color(_prefix() + message, Fore.MAGENTA)

--- a/ia_manager/services/memory.py
+++ b/ia_manager/services/memory.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from .storage import DATA_DIR
+
+USER_FILE = DATA_DIR / "memory.json"
+NOTES_FILE = DATA_DIR / "notes.json"
+
+
+def load_user() -> dict:
+    if not USER_FILE.exists():
+        return {"name": "User", "sarcasm": 1}
+    with open(USER_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_user(user: dict):
+    USER_FILE.parent.mkdir(exist_ok=True)
+    with open(USER_FILE, "w", encoding="utf-8") as f:
+        json.dump(user, f, indent=2, ensure_ascii=False)
+
+
+def load_notes() -> list:
+    if not NOTES_FILE.exists():
+        return []
+    with open(NOTES_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_notes(notes: list):
+    NOTES_FILE.parent.mkdir(exist_ok=True)
+    with open(NOTES_FILE, "w", encoding="utf-8") as f:
+        json.dump(notes, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- implement persistent memory and note storage
- add sarcastic personality layer
- extend CLI with `remember`, `recall`, `set_sarcasm` and `set_name`
- update interactive shell greeting and help
- document new features in README
- provide example `memory.json` and `notes.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m ia_manager --help`
- `python -m ia_manager remember "First note" --tags test`
- `python -m ia_manager recall test`
- `python -m ia_manager set_sarcasm 2`


------
https://chatgpt.com/codex/tasks/task_e_685adf6d71b883248bc70b5abbfde191