### PR TITLE
Integrate thought generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,4 +146,6 @@ Start both the web interface and the thought API with:
 ```
 python -m ia_manager.start_servers
 ```
-This requires `flask` and `llama-cpp-python`. The assistant calls `http://localhost:8080/pensee` to generate internal thoughts.
+The helper script launches the two Flask apps in separate threads (without
+reloaders). This requires `flask` and `llama-cpp-python`. The assistant calls
+`http://localhost:8080/pensee` to generate internal thoughts.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ These internal notes are indexed for context but hidden from CLI commands and
 web search results.
 
 A developer mode can be enabled in the personality settings. When activated,
-each chat displays the raw search snippets and the generated internal thought
-before sending the request to OpenAI.
+the chat interface shows a grey box containing the related search snippets and
+the generated internal thought before sending the request to OpenAI.
 
 All chat messages are written to `ia_manager/data/log.txt` so you can audit the
 conversation history if needed.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,14 @@ web search results.
 
 A developer mode can be enabled in the personality settings. When activated,
 the chat interface shows a grey box containing the related search snippets and
-the generated internal thought before sending the request to OpenAI.
+the generated internal thought before sending the request to OpenAI. The
+assistant prepends this thought to the OpenAI prompt using the format:
+
+```
+Pensée interne : <thought>
+User : <message>
+```
+
 
 All chat messages are written to `ia_manager/data/log.txt` so you can audit the
 conversation history if needed.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Click a task to open a detail modal where you can start/stop the timer or mark i
 New tasks are added through a dedicated form with name, description and deadline fields.
 Action notifications suggested by the AI appear in the bottom right corner with accept/decline buttons.
 The right column lists upcoming deadlines while the centre shows the task the AI recommends to start now.
-The **Browser** page now acts as a search engine over your notes and past messages. Enter a few keywords to get a short paragraph summarising the most relevant texts (max 500 characters).
+The **Browser** page now acts as a search engine over your saved souvenirs. Enter a few keywords to get a short paragraph summarising the most relevant texts (max 500 characters).
 Navigate using the left menu to switch between the dashboard, project view,
 global tasks list, calendar, chat, the built-in browser and settings.
 
@@ -108,11 +108,12 @@ In the web interface, open the **Settings** page to adjust the assistant
 sarcasm level, the maximum length of search snippets and your custom session
 note.
 
-When chatting with the assistant, each message is stored in the memory file and
-automatically searched for related facts. These facts along with the last
-chat messages are sent to a local API at `http://localhost:8080/pensee` which
-returns an internal thought guiding the assistant. This thought is prepended
-before your message so the OpenAI model can respond with better context.
+When chatting with the assistant, the local model generates "souvenirs" that are
+stored in the memory file. Only these souvenirs are searched for related
+information. The most relevant ones together with the latest chat lines are sent
+to a local API at `http://localhost:8080/pensee` which returns an internal
+thought guiding the assistant. This thought is prepended before your message so
+the OpenAI model can reply with better context.
 
 The assistant can also store private notes using the `remember_note` function.
 These internal notes are indexed for context but hidden from CLI commands and
@@ -141,8 +142,8 @@ Place any `gguf` files inside the `models` folder to experiment with local
 Llama models. They can be loaded through the Settings page but are not used
 automatically when chatting.
 
-Start the thought API with:
+Start both the web interface and the thought API with:
 ```
-python -m ia_manager.thought_server
+python -m ia_manager.start_servers
 ```
 This requires `flask` and `llama-cpp-python`. The assistant calls `http://localhost:8080/pensee` to generate internal thoughts.

--- a/README.md
+++ b/README.md
@@ -140,3 +140,9 @@ for reference.
 Place any `gguf` files inside the `models` folder to experiment with local
 Llama models. They can be loaded through the Settings page but are not used
 automatically when chatting.
+
+Start the thought API with:
+```
+python -m ia_manager.thought_server
+```
+This requires `flask` and `llama-cpp-python`. The assistant calls `http://localhost:8080/pensee` to generate internal thoughts.

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ sarcasm level, the maximum length of search snippets and your custom session
 note.
 
 When chatting with the assistant, each message is stored in the memory file and
-automatically searched to provide context. The search engine now scores each
-note or past message based on how many query keywords it contains,
-similar to a web browser. The most relevant snippets are summarised and
-prepended before each request to keep token usage low.
+automatically searched for related facts. These facts along with the last
+chat messages are sent to a local API at `http://localhost:8080/pensee` which
+returns an internal thought guiding the assistant. This thought is prepended
+before your message so the OpenAI model can respond with better context.
 
 The assistant can also store private notes using the `remember_note` function.
 These internal notes are indexed for context but hidden from CLI commands and
@@ -120,12 +120,12 @@ web search results. Use `remember_fact` to store a regular fact that will later
 appear in search results.
 
 A developer mode can be enabled in the personality settings. When activated,
-the chat interface shows a grey box containing the search snippets sent with
-each request. The assistant receives this context using the format:
+the chat interface shows a grey debug box containing the related facts and the
+internal thought used for the response. The prompt sent to OpenAI looks like:
 
 ```
-mémoire pouvant être utile: <context>
-User : <message>
+Pensée interne de l'IA : <thought>
+Utilisateur : <message>
 ```
 
 
@@ -137,8 +137,6 @@ for reference.
 
 ## Local models
 
-Place any `gguf` files inside the `models` folder to use a local Llama model.
-Select the desired model in the Settings page and edit the prompt used to
-generate new memory notes. When a message is sent, it is first processed by the
-local model which may store a new fact before the OpenAI assistant receives the
-query along with relevant search results.
+Place any `gguf` files inside the `models` folder to experiment with local
+Llama models. They can be loaded through the Settings page but are not used
+automatically when chatting.

--- a/README.md
+++ b/README.md
@@ -116,15 +116,15 @@ prepended before each request to keep token usage low.
 
 The assistant can also store private notes using the `remember_note` function.
 These internal notes are indexed for context but hidden from CLI commands and
-web search results.
+web search results. Use `remember_fact` to store a regular fact that will later
+appear in search results.
 
 A developer mode can be enabled in the personality settings. When activated,
-the chat interface shows a grey box containing the related search snippets and
-the generated internal thought before sending the request to OpenAI. The
-assistant prepends this thought to the OpenAI prompt using the format:
+the chat interface shows a grey box containing the search snippets sent with
+each request. The assistant receives this context using the format:
 
 ```
-Pensée interne : <thought>
+mémoire pouvant être utile: <context>
 User : <message>
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,3 +134,11 @@ conversation history if needed.
 
 All callable functions are listed in `ia_manager/data/assistant_commands.json`
 for reference.
+
+## Local models
+
+Place any `gguf` files inside the `models` folder to use a local Llama model.
+Select the desired model in the Settings page and edit the prompt used to
+generate new memory notes. When a message is sent, it is first processed by the
+local model which may store a new fact before the OpenAI assistant receives the
+query along with relevant search results.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ The assistant can also store private notes using the `remember_note` function.
 These internal notes are indexed for context but hidden from CLI commands and
 web search results.
 
+A developer mode can be enabled in the personality settings. When activated,
+each chat displays the raw search snippets and the generated internal thought
+before sending the request to OpenAI.
+
 All chat messages are written to `ia_manager/data/log.txt` so you can audit the
 conversation history if needed.
 

--- a/ia_manager/assistant.py
+++ b/ia_manager/assistant.py
@@ -177,14 +177,14 @@ def _get_thought(message: str) -> tuple[str, list[str], list[str]]:
     """Generate an internal thought using the local API."""
     user = memory.load_user()
     facts = memory.related_facts(message)
-    recent = memory.last_messages()
+    recent = memory.last_messages(count=1)
     if user.dev_mode:
         print(f"[DEV] related facts: {facts}")
         print(f"[DEV] last messages: {recent}")
     payload = {"souvenirs": facts, "derniers_messages": recent}
     thought = ""
     try:
-        resp = requests.post("http://localhost:8080/pensee", json=payload, timeout=5)
+        resp = requests.post("http://127.0.0.1:8080/pensee", json=payload, timeout=5)
         resp.raise_for_status()
         data = resp.json()
         thought = data.get("pensee", "")

--- a/ia_manager/assistant.py
+++ b/ia_manager/assistant.py
@@ -175,8 +175,12 @@ def _execute(func_name: str, params: dict) -> str:
 
 def _get_thought(message: str) -> str:
     """Generate an internal thought using the local API."""
+    user = memory.load_user()
     facts = memory.related_facts(message)
     recent = memory.last_messages()
+    if user.dev_mode:
+        print(f"[DEV] related facts: {facts}")
+        print(f"[DEV] last messages: {recent}")
     payload = {"souvenirs": facts, "derniers_messages": recent}
     try:
         resp = requests.post("http://localhost:8080/pensee", json=payload, timeout=5)
@@ -185,6 +189,9 @@ def _get_thought(message: str) -> str:
         thought = data.get("pensee", "")
         if thought:
             logger.log(f"pensee: {thought}")
+            memory.add_internal_note(thought)
+            if user.dev_mode:
+                print(f"[DEV] pensee: {thought}")
         return thought
     except Exception as exc:
         logger.log(f"pensee error: {exc}")

--- a/ia_manager/assistant.py
+++ b/ia_manager/assistant.py
@@ -207,7 +207,11 @@ def send_message(message: str) -> str:
     if context:
         print(f"[CONTEXT] {context}")
         logger.log(f"context: {context}")
-    content = f"Pensée interne de l\u2019IA : {thought}\nUtilisateur : {message}" if thought else f"Utilisateur : {message}"
+    content = (
+        f"Pensée interne : {thought}\nUser : {message}"
+        if thought
+        else f"User : {message}"
+    )
     if context:
         full = f"{context}\n{content}"
     else:
@@ -326,7 +330,11 @@ def send_message_events(message: str):
     if context:
         print(f"[CONTEXT] {context}")
         logger.log(f"context: {context}")
-    content = f"Pensée interne de l\u2019IA : {thought}\nUtilisateur : {message}" if thought else f"Utilisateur : {message}"
+    content = (
+        f"Pensée interne : {thought}\nUser : {message}"
+        if thought
+        else f"User : {message}"
+    )
     if context:
         full = f"{context}\n{content}"
     else:

--- a/ia_manager/cli/commands.py
+++ b/ia_manager/cli/commands.py
@@ -407,6 +407,8 @@ def set_personality(args):
         user.sarcasm = max(0.0, min(1.0, args.sarcasm))
     if args.context_chars is not None:
         user.context_chars = max(100, min(1000, args.context_chars))
+    if args.dev_mode is not None:
+        user.dev_mode = args.dev_mode
     memory.save_user(user)
     print("Personality updated")
 
@@ -414,7 +416,7 @@ def set_personality(args):
 def show_personality(_args):
     user = memory.load_user()
     print(
-        f"User: {user.name}, sarcasm: {user.sarcasm}, context chars: {user.context_chars}"
+        f"User: {user.name}, sarcasm: {user.sarcasm}, context chars: {user.context_chars}, dev mode: {user.dev_mode}"
     )
 
 
@@ -547,6 +549,9 @@ def build_parser() -> argparse.ArgumentParser:
     pers = sub.add_parser("set_personality")
     pers.add_argument("--sarcasm", type=float)
     pers.add_argument("--context_chars", type=int)
+    pers.add_argument("--dev", dest="dev_mode", action="store_true")
+    pers.add_argument("--no-dev", dest="dev_mode", action="store_false")
+    pers.set_defaults(dev_mode=None)
     pers.set_defaults(func=set_personality)
 
     sub.add_parser("show_personality").set_defaults(func=show_personality)

--- a/ia_manager/cli/commands.py
+++ b/ia_manager/cli/commands.py
@@ -401,6 +401,11 @@ def add_internal_note_cmd(args):
     print("Internal note added")
 
 
+def add_fact_cmd(args):
+    memory.add_fact(args.text)
+    print("Fact recorded")
+
+
 def set_personality(args):
     user = memory.load_user()
     if args.sarcasm is not None:
@@ -545,6 +550,10 @@ def build_parser() -> argparse.ArgumentParser:
     priv = sub.add_parser("remember_note")
     priv.add_argument("text")
     priv.set_defaults(func=add_internal_note_cmd)
+
+    fact = sub.add_parser("remember_fact")
+    fact.add_argument("text")
+    fact.set_defaults(func=add_fact_cmd)
 
     pers = sub.add_parser("set_personality")
     pers.add_argument("--sarcasm", type=float)

--- a/ia_manager/data/personality.json
+++ b/ia_manager/data/personality.json
@@ -2,5 +2,7 @@
   "name": "Alex",
   "sarcasm": 0.5,
   "context_chars": 500,
-  "dev_mode": false
+  "dev_mode": false,
+  "local_model": "",
+  "local_prompt": "Sauvegarde ce qui est important: {message}"
 }

--- a/ia_manager/data/personality.json
+++ b/ia_manager/data/personality.json
@@ -1,5 +1,6 @@
 {
   "name": "Alex",
   "sarcasm": 0.5,
-  "context_chars": 500
+  "context_chars": 500,
+  "dev_mode": false
 }

--- a/ia_manager/models/user.py
+++ b/ia_manager/models/user.py
@@ -6,6 +6,8 @@ class User:
     sarcasm: float = 0.3  # 0 (none) to 1 (high)
     context_chars: int = 500  # max characters returned by search
     dev_mode: bool = False  # show extra debug info
+    local_model: str = ""
+    local_prompt: str = "Sauvegarde ce qui est important: {message}"
 
     def to_dict(self) -> dict:
         return {
@@ -13,6 +15,8 @@ class User:
             "sarcasm": self.sarcasm,
             "context_chars": self.context_chars,
             "dev_mode": self.dev_mode,
+            "local_model": self.local_model,
+            "local_prompt": self.local_prompt,
         }
 
     @staticmethod
@@ -22,4 +26,6 @@ class User:
             sarcasm=data.get("sarcasm", 0.3),
             context_chars=data.get("context_chars", 500),
             dev_mode=data.get("dev_mode", False),
+            local_model=data.get("local_model", ""),
+            local_prompt=data.get("local_prompt", "Sauvegarde ce qui est important: {message}"),
         )

--- a/ia_manager/models/user.py
+++ b/ia_manager/models/user.py
@@ -5,12 +5,14 @@ class User:
     name: str = "User"
     sarcasm: float = 0.3  # 0 (none) to 1 (high)
     context_chars: int = 500  # max characters returned by search
+    dev_mode: bool = False  # show extra debug info
 
     def to_dict(self) -> dict:
         return {
             "name": self.name,
             "sarcasm": self.sarcasm,
             "context_chars": self.context_chars,
+            "dev_mode": self.dev_mode,
         }
 
     @staticmethod
@@ -19,4 +21,5 @@ class User:
             name=data.get("name", "User"),
             sarcasm=data.get("sarcasm", 0.3),
             context_chars=data.get("context_chars", 500),
+            dev_mode=data.get("dev_mode", False),
         )

--- a/ia_manager/services/local_model.py
+++ b/ia_manager/services/local_model.py
@@ -39,6 +39,7 @@ def current_model() -> Optional[str]:
 
 
 def ensure_loaded() -> None:
+    global _llm, _model_name
     user = memory.load_user()
     name = user.local_model
     if name and name != _model_name:

--- a/ia_manager/services/local_model.py
+++ b/ia_manager/services/local_model.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional
+
+try:
+    from llama_cpp import Llama
+except Exception:  # pragma: no cover - optional dependency
+    Llama = None  # type: ignore
+
+from . import memory
+
+MODEL_DIR = Path(__file__).resolve().parent.parent / "models"
+
+_llm: Optional["Llama"] = None
+_model_name: Optional[str] = None
+
+
+def available_models() -> list[str]:
+    """Return the list of .gguf models found in the models folder."""
+    return [p.name for p in MODEL_DIR.glob("*.gguf")]
+
+
+def load_model(name: str) -> None:
+    """Load the given local model if llama_cpp is available."""
+    global _llm, _model_name
+    if Llama is None:
+        _llm = None
+        _model_name = None
+        return
+    path = MODEL_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(path)
+    _llm = Llama(model_path=str(path))
+    _model_name = name
+
+
+def current_model() -> Optional[str]:
+    return _model_name
+
+
+def ensure_loaded() -> None:
+    user = memory.load_user()
+    name = user.local_model
+    if name and name != _model_name:
+        try:
+            load_model(name)
+        except Exception as exc:  # pragma: no cover - runtime issue
+            print(f"[ERROR] Failed to load model {name}: {exc}")
+            _llm = None
+            _model_name = None
+
+
+def process_message(message: str) -> Optional[str]:
+    """Send the message to the local model and store the returned note."""
+    ensure_loaded()
+    if _llm is None:
+        return None
+    user = memory.load_user()
+    prompt = (user.local_prompt or "{message}").format(message=message)
+    try:
+        out = _llm(prompt, max_tokens=64)
+    except Exception as exc:  # pragma: no cover - runtime issue
+        print(f"[ERROR] Local model inference failed: {exc}")
+        return None
+    text = out["choices"][0]["text"].strip()
+    if text:
+        memory.add_fact(text)
+    return text

--- a/ia_manager/services/memory.py
+++ b/ia_manager/services/memory.py
@@ -175,3 +175,22 @@ def get_context(query: str, max_chars: int | None = None, include_internal: bool
         parts.append("Messages: " + "; ".join(h["text"] for h in hist))
     ctx = " ".join(parts)
     return ctx[:max_chars]
+
+
+def related_facts(query: str, limit: int = 3) -> list[str]:
+    """Return short texts from notes and history related to the query."""
+    notes = search_notes(query, limit=limit, include_internal=True)
+    hist = search_history(query, limit=limit)
+    facts = [n.text for n in notes]
+    facts.extend(h.get("text", "") for h in hist)
+    return facts
+
+
+def last_messages(count: int = 5) -> list[str]:
+    """Return the most recent chat messages formatted with roles."""
+    history = load_history()
+    messages = []
+    for item in history[-count:]:
+        role = "Utilisateur" if item.get("role") == "user" else "IA"
+        messages.append(f"{role} : {item.get('text', '')}")
+    return messages

--- a/ia_manager/services/memory.py
+++ b/ia_manager/services/memory.py
@@ -49,6 +49,14 @@ def add_internal_note(text: str):
     save_notes(notes)
 
 
+def add_fact(text: str):
+    """Store an important fact visible in search results."""
+    notes = load_notes()
+    note_id = max([n.id for n in notes], default=0) + 1
+    notes.append(Note(id=note_id, text=text))
+    save_notes(notes)
+
+
 def load_custom_session_note() -> str:
     mem = load_memory()
     return mem.get("session_note", "")

--- a/ia_manager/services/memory.py
+++ b/ia_manager/services/memory.py
@@ -171,27 +171,21 @@ def search_notes(
 
 
 def get_context(query: str, max_chars: int | None = None, include_internal: bool = False) -> str:
-    """Return a short summary of history and notes related to the query."""
+    """Return a short summary of notes related to the query."""
     if max_chars is None:
         max_chars = load_user().context_chars
     notes = search_notes(query, include_internal=include_internal)
-    hist = search_history(query)
     parts = []
     if notes:
         parts.append("Notes: " + "; ".join(n.text for n in notes))
-    if hist:
-        parts.append("Messages: " + "; ".join(h["text"] for h in hist))
     ctx = " ".join(parts)
     return ctx[:max_chars]
 
 
 def related_facts(query: str, limit: int = 3) -> list[str]:
-    """Return short texts from notes and history related to the query."""
+    """Return short texts from notes related to the query."""
     notes = search_notes(query, limit=limit, include_internal=True)
-    hist = search_history(query, limit=limit)
-    facts = [n.text for n in notes]
-    facts.extend(h.get("text", "") for h in hist)
-    return facts
+    return [n.text for n in notes]
 
 
 def last_messages(count: int = 5) -> list[str]:

--- a/ia_manager/start_servers.py
+++ b/ia_manager/start_servers.py
@@ -1,24 +1,28 @@
-from multiprocessing import Process
+"""Launch the web and thought servers simultaneously."""
+
+from threading import Thread
 from .web.server import app as web_app
 from .thought_server import app as thought_app
 
 
-def run_web():
-    web_app.run(debug=True)
+def run_web() -> None:
+    """Run the Flask web server without the reloader."""
+    web_app.run(debug=True, use_reloader=False)
 
 
-def run_thought():
-    thought_app.run(host="0.0.0.0", port=8080)
+def run_thought() -> None:
+    """Run the local thought API without the reloader."""
+    thought_app.run(host="0.0.0.0", port=8080, use_reloader=False)
 
 
 def main():
-    p1 = Process(target=run_web)
-    p2 = Process(target=run_thought)
-    p1.start()
-    p2.start()
+    t1 = Thread(target=run_web, daemon=True)
+    t2 = Thread(target=run_thought, daemon=True)
+    t1.start()
+    t2.start()
     try:
-        p1.join()
-        p2.join()
+        t1.join()
+        t2.join()
     except KeyboardInterrupt:
         pass
 

--- a/ia_manager/start_servers.py
+++ b/ia_manager/start_servers.py
@@ -1,0 +1,27 @@
+from multiprocessing import Process
+from .web.server import app as web_app
+from .thought_server import app as thought_app
+
+
+def run_web():
+    web_app.run(debug=True)
+
+
+def run_thought():
+    thought_app.run(host="0.0.0.0", port=8080)
+
+
+def main():
+    p1 = Process(target=run_web)
+    p2 = Process(target=run_thought)
+    p1.start()
+    p2.start()
+    try:
+        p1.join()
+        p2.join()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/ia_manager/thought_server.py
+++ b/ia_manager/thought_server.py
@@ -1,0 +1,25 @@
+from flask import Flask, request, jsonify
+from .services import local_model
+
+app = Flask(__name__)
+
+@app.route('/pensee', methods=['POST'])
+def pensee_api():
+    data = request.get_json(silent=True) or {}
+    souvenirs = data.get('souvenirs', [])
+    derniers = data.get('derniers_messages', [])
+
+    parts = []
+    if souvenirs:
+        parts.append("Souvenirs:\n" + "\n".join(f"- {s}" for s in souvenirs))
+    if derniers:
+        parts.append("Derniers messages:\n" + "\n".join(derniers))
+    parts.append("Quelle est la pens\u00e9e actuelle de l'IA ?")
+    prompt = "\n\n".join(parts)
+
+    text = local_model.process_message(prompt) or ""
+    return jsonify({'pensee': text})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/ia_manager/web/server.py
+++ b/ia_manager/web/server.py
@@ -2,7 +2,7 @@ from flask import Flask, jsonify, request, render_template, Response
 from datetime import datetime, timedelta
 import re
 import json
-from ..services import storage, planner, logger, memory
+from ..services import storage, planner, logger, memory, local_model
 from .. import assistant
 from ..models.project import Project
 from ..models.task import Task
@@ -352,6 +352,12 @@ def search_api():
     return jsonify({'result': result})
 
 
+@app.route('/api/local_models')
+def local_models_api():
+    """Return available local model filenames."""
+    return jsonify({'models': local_model.available_models()})
+
+
 @app.route('/api/personality', methods=['GET', 'POST'])
 def personality_api():
     """Get or update user personality."""
@@ -376,6 +382,10 @@ def personality_api():
         user.context_chars = max(100, min(1000, user.context_chars))
     if 'dev_mode' in data:
         user.dev_mode = bool(data['dev_mode'])
+    if 'local_model' in data:
+        user.local_model = data['local_model']
+    if 'local_prompt' in data:
+        user.local_prompt = data['local_prompt']
     memory.save_user(user)
     return jsonify(user.to_dict())
 

--- a/ia_manager/web/server.py
+++ b/ia_manager/web/server.py
@@ -374,6 +374,8 @@ def personality_api():
         except (TypeError, ValueError):
             pass
         user.context_chars = max(100, min(1000, user.context_chars))
+    if 'dev_mode' in data:
+        user.dev_mode = bool(data['dev_mode'])
     memory.save_user(user)
     return jsonify(user.to_dict())
 

--- a/ia_manager/web/static/main.js
+++ b/ia_manager/web/static/main.js
@@ -330,6 +330,10 @@ function formatDebug(info) {
     if (info.memory) {
         html += '<b>Mémoire:</b> ' + escapeHtml(info.memory);
     }
+    if (info.thought) {
+        if (html) html += '<br>';
+        html += '<b>Pensée:</b> ' + escapeHtml(info.thought);
+    }
     return html;
 }
 

--- a/ia_manager/web/static/main.js
+++ b/ia_manager/web/static/main.js
@@ -321,6 +321,24 @@ async function loadDashboard() {
     document.getElementById('proposal-text').textContent = rec;
 }
 
+function escapeHtml(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function formatDebug(info) {
+    let html = '';
+    if (info.thought) {
+        html += '<b>Pensée:</b> ' + escapeHtml(info.thought) + '<br>';
+    }
+    if (info.facts && info.facts.length) {
+        html += '<b>Faits:</b><ul>' + info.facts.map(f => '<li>' + escapeHtml(f) + '</li>').join('') + '</ul>';
+    }
+    if (info.recent && info.recent.length) {
+        html += '<b>Messages:</b><ul>' + info.recent.map(m => '<li>' + escapeHtml(m) + '</li>').join('') + '</ul>';
+    }
+    return html;
+}
+
 
 async function sendMessage() {
     const input = document.getElementById('message');
@@ -346,6 +364,16 @@ async function sendMessage() {
     const src = new EventSource('/api/chat/stream?message=' + encodeURIComponent(msg));
     src.onmessage = (ev) => {
         const data = JSON.parse(ev.data);
+        if (data.debug && document.getElementById('dev-mode').checked) {
+            const d = document.createElement('div');
+            d.className = 'dev-msg';
+            const ds = document.createElement('span');
+            ds.innerHTML = formatDebug(data.debug);
+            d.appendChild(ds);
+            log.insertBefore(d, r);
+            log.scrollTop = log.scrollHeight;
+            return;
+        }
         if (data.action) {
             const a = document.createElement('div');
             a.className = 'bot-msg';

--- a/ia_manager/web/static/main.js
+++ b/ia_manager/web/static/main.js
@@ -435,6 +435,16 @@ async function loadSettings() {
     document.getElementById('sarcasm-level').value = user.sarcasm;
     document.getElementById('context-length').value = user.context_chars || 500;
     document.getElementById('dev-mode').checked = user.dev_mode || false;
+    const mRes = await fetch('/api/local_models');
+    const models = await mRes.json();
+    const sel = document.getElementById('local-model');
+    sel.innerHTML = '<option value="">-- none --</option>';
+    models.models.forEach(m => {
+        const opt = document.createElement('option');
+        opt.value = m; opt.textContent = m; sel.appendChild(opt);
+    });
+    sel.value = user.local_model || '';
+    document.getElementById('local-prompt').value = user.local_prompt || '';
     const nRes = await fetch('/api/session_note');
     const note = await nRes.json();
     document.getElementById('session-note').value = note.note || '';
@@ -444,11 +454,13 @@ async function saveSettings() {
     const sarcasm = parseFloat(document.getElementById('sarcasm-level').value);
     const chars = parseInt(document.getElementById('context-length').value, 10);
     const dev = document.getElementById('dev-mode').checked;
+    const localModel = document.getElementById('local-model').value;
+    const localPrompt = document.getElementById('local-prompt').value;
     const note = document.getElementById('session-note').value;
     await fetch('/api/personality', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sarcasm, context_chars: chars, dev_mode: dev })
+        body: JSON.stringify({ sarcasm, context_chars: chars, dev_mode: dev, local_model: localModel, local_prompt: localPrompt })
     });
     await fetch('/api/session_note', {
         method: 'POST',

--- a/ia_manager/web/static/main.js
+++ b/ia_manager/web/static/main.js
@@ -327,14 +327,8 @@ function escapeHtml(str) {
 
 function formatDebug(info) {
     let html = '';
-    if (info.thought) {
-        html += '<b>Pensée:</b> ' + escapeHtml(info.thought) + '<br>';
-    }
-    if (info.facts && info.facts.length) {
-        html += '<b>Faits:</b><ul>' + info.facts.map(f => '<li>' + escapeHtml(f) + '</li>').join('') + '</ul>';
-    }
-    if (info.recent && info.recent.length) {
-        html += '<b>Messages:</b><ul>' + info.recent.map(m => '<li>' + escapeHtml(m) + '</li>').join('') + '</ul>';
+    if (info.memory) {
+        html += '<b>Mémoire:</b> ' + escapeHtml(info.memory);
     }
     return html;
 }

--- a/ia_manager/web/static/main.js
+++ b/ia_manager/web/static/main.js
@@ -412,6 +412,7 @@ async function loadSettings() {
     const user = await uRes.json();
     document.getElementById('sarcasm-level').value = user.sarcasm;
     document.getElementById('context-length').value = user.context_chars || 500;
+    document.getElementById('dev-mode').checked = user.dev_mode || false;
     const nRes = await fetch('/api/session_note');
     const note = await nRes.json();
     document.getElementById('session-note').value = note.note || '';
@@ -420,11 +421,12 @@ async function loadSettings() {
 async function saveSettings() {
     const sarcasm = parseFloat(document.getElementById('sarcasm-level').value);
     const chars = parseInt(document.getElementById('context-length').value, 10);
+    const dev = document.getElementById('dev-mode').checked;
     const note = document.getElementById('session-note').value;
     await fetch('/api/personality', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sarcasm, context_chars: chars })
+        body: JSON.stringify({ sarcasm, context_chars: chars, dev_mode: dev })
     });
     await fetch('/api/session_note', {
         method: 'POST',

--- a/ia_manager/web/static/styles.css
+++ b/ia_manager/web/static/styles.css
@@ -289,6 +289,17 @@ button.wide {
     border-bottom-left-radius: 0;
 }
 
+.dev-msg {
+    justify-content: center;
+}
+
+.dev-msg span {
+    background: #444;
+    color: #fff;
+    font-size: 12px;
+    border-radius: 8px;
+}
+
 .bot-msg span.action {
     background: transparent;
     color: var(--muted-color);

--- a/ia_manager/web/static/styles.css
+++ b/ia_manager/web/static/styles.css
@@ -177,6 +177,7 @@ li.done {
 }
 
 .form input,
+.form select,
 .form textarea {
     flex: 1;
     background: #222;

--- a/ia_manager/web/templates/index.html
+++ b/ia_manager/web/templates/index.html
@@ -78,6 +78,9 @@
                 <label>Search snippet size
                     <input id="context-length" type="number" min="100" max="1000" step="50">
                 </label>
+                <label class="checkbox">
+                    <input id="dev-mode" type="checkbox"> Dev mode
+                </label>
                 <label>Session note
                     <textarea id="session-note" rows="3"></textarea>
                 </label>

--- a/ia_manager/web/templates/index.html
+++ b/ia_manager/web/templates/index.html
@@ -81,6 +81,12 @@
                 <label class="checkbox">
                     <input id="dev-mode" type="checkbox"> Dev mode
                 </label>
+                <label>Local model
+                    <select id="local-model"></select>
+                </label>
+                <label>Local prompt
+                    <textarea id="local-prompt" rows="3"></textarea>
+                </label>
                 <label>Session note
                     <textarea id="session-note" rows="3"></textarea>
                 </label>


### PR DESCRIPTION
## Summary
- add utilities to retrieve related facts and recent messages
- hook up new external API to build internal thoughts
- insert generated thought into assistant prompts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c208142b88324af4ea068e8cd5c56